### PR TITLE
Fetch with uidnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ pip install .
 
 ### 3.2. Basic Usage
 
-An [observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) is used for processing incoming emails.  To receive email events, a class must implement the on_mail_received method of the EmailObserver class.  This callback is triggered when EmailNotifier is started, when one or more new messages arrive, or when messages are deleted, or moved.
+An [observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) is used for processing incoming emails.  To receive email events, a class must implement the on_mail_received method of the EmailObserver class.  This callback is triggered when one or more new messages arrive, or are moved to the mailbox.
 
-The optional parameter message_list_len specifies the maximum length of the message_list that is passed to the observer.  This list contains all messages in the mailbox from the most recent message, up to the specified depth.
+Each new message is an `email.message.Message` object from the built-in [email](https://docs.python.org/3/library/email.html) module.
 
 ```python
 from emailobserver import EmailNotifier, EmailObserver
+from email.message import Message
 
-class Observer(EmailObserver):
-    def on_mail_received(self, new_messages: list, message_list: list):
+class ConcreteObserver(EmailObserver):
+    def on_mail_received(self, new_messages: list[Message]):
         print(len(new_messages), "New messages received.")
 
-observer = Observer()
+observer = ConcreteObserver()
 
-notifier = EmailNotifier('imap.someserver.com', 'someuser@someserver.com', 'password', 
-                         message_list_len=10)
+notifier = EmailNotifier('imap.someserver.com', 'someuser@someserver.com', 'password')
 notifier.register_observer(observer)
 notifier.start()
 ```

--- a/emailobserver/email_notifier.py
+++ b/emailobserver/email_notifier.py
@@ -125,24 +125,25 @@ class EmailNotifier:
     """This is the subject which maintains a list of observers.  When one or
     more emails are received, all observers are notified by calling their
     on_mail_received method."""
-    def __init__(self, imap_server=None, email_user=None, email_password=None, mailbox='Inbox', imap_port=None, **kwargs):
+    def __init__(self, email_user=None, email_password=None, imap_server=None, mailbox='Inbox', imap_port=None, **kwargs):
         self._first = True
-        self.imap_server = imap_server
         self.email_user = email_user
         self.email_password = email_password
+        self.imap_server = imap_server
         self.mailbox = mailbox
         self.imap_port = imap_port
 
         # Load email server credentials from environment variables if not provided
-        imap_server_env = kwargs.get("imap_server_env") or "EMAIL_OBSERVER_IMAP_SERVER"
         email_user_env = kwargs.get("email_user_env") or "EMAIL_OBSERVER_USER"
         email_password_env = kwargs.get("email_password_env") or "EMAIL_OBSERVER_PASSWORD"
-        if not self.imap_server:
-            self.imap_server = os.getenv(imap_server_env)
+        imap_server_env = kwargs.get("imap_server_env") or "EMAIL_OBSERVER_IMAP_SERVER"
         if not self.email_user:
             self.email_user = os.getenv(email_user_env)
         if not self.email_password:
             self.email_password = os.getenv(email_password_env)
+        if not self.imap_server:
+            self.imap_server = os.getenv(imap_server_env)
+
         if not all((self.imap_server, self.email_user, self.email_password)):
             raise EnvironmentError(
                 "{}, {}, and {} must be set as environment variables, or values must be passed in as arguments to {} constructor.".format(

--- a/emailobserver/email_notifier.py
+++ b/emailobserver/email_notifier.py
@@ -171,6 +171,9 @@ class EmailNotifier:
                 try:
                     imap_client = imaplib2.IMAP4_SSL(self.imap_server, self.imap_port)
                     imap_client.login(self.email_user, self.email_password)
+                    if 'IDLE' not in imap_client.capabilities:
+                        logging.error("IMAP server does not support IDLE which is required for EmailNotifier to work.")
+                        return
                     imap_client.select(self.mailbox)  # We need to get out of the AUTH state, so we just select the INBOX.
 
                     null_uidnext_uidvalidity = self.uidnext is None or self.uidvalidity is None
@@ -179,7 +182,7 @@ class EmailNotifier:
 
                     self.imapClientManager = IMAPClientManager(imap_client, self.fetch_newest_emails)  # Start the Idler thread
                     self.imapClientManager.start()
-                    logging.info(f'IMAP listening has started for {self.mailbox}')
+                    logging.info(f'IMAP listening has started for "{self.mailbox}"')
 
                     if not null_uidnext_uidvalidity:
                         self.fetch_newest_emails()

--- a/emailobserver/email_notifier.py
+++ b/emailobserver/email_notifier.py
@@ -230,9 +230,10 @@ class EmailNotifier:
                 assert self.uidnext is not None
                 assert self.uidvalidity is not None
                 if uidvalidity != self.uidvalidity:
-                   logging.warning(f"UIDVALIDITY has changed!  This means that mailbox {self.mailbox} has experienced a signifigant change.")
-                   self.uidnext, self.uidvalidity = uidnext, uidvalidity
-                   return
+                    logging.warning(f"UIDVALIDITY has changed!  This means that mailbox {self.mailbox} has experienced "
+                                    "a significant change.")
+                    self.uidnext, self.uidvalidity = uidnext, uidvalidity
+                    return
 
                 result, msg_data = imap_client.uid('FETCH', f'{self.uidnext}:*', '(RFC822)')
                 self.uidnext = uidnext

--- a/emailobserver/email_notifier.py
+++ b/emailobserver/email_notifier.py
@@ -195,7 +195,7 @@ class EmailNotifier:
                     logging.info('IMAP listening has stopped, conn cleanup was run for: Listener: {}, Client: {}'
                                  .format(self.imapClientManager is not None, imap_client is not None))
                     sys.stdout.flush()  # probably not needed
-            except imaplib2.IMAP4.abort as e:
+            except imaplib2.IMAP4.abort:
                 retry_delay_s = 1
                 sleep_unless(retry_delay_s, lambda: self.killer.kill_now)
                 if self.killer.kill_now:
@@ -212,7 +212,6 @@ class EmailNotifier:
             imap_client.select(self.mailbox)
 
             result, data = imap_client.uid('SEARCH', None, 'ALL')
-            uids = data[0].split()
             all_uids = {int(b) for b in data[0].split()}
 
             uids_to_fetch = reversed([int(b) for b in data[0].split()[-self.message_list_len:]])


### PR DESCRIPTION
UIDNEXT is used to determine changes in the mailbox rather than fetching and comparing all UIDs.  This is more efficient.  UIDNEXT is retreived by issuing a status command.  Messages are fetched using the range "UIDNEXT:*".

Removed message_list from callback signature.  Only returns a list of new_messages.